### PR TITLE
Install individual packages instead of collections

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,6 @@ TEXMFHOME \$TEXMFLOCAL
 TEXMFVAR \$TEXMFSYSVAR
 binary_x86_64-linux 1
 collection-basic 1
-collection-binextra 1
 collection-latex 1
 instopt_adjustpath 1
 instopt_adjustrepo 1
@@ -65,6 +64,7 @@ if [ ! -e "$INSTALL_TL_SUCCESS" ]; then
 
   echo "[$0] Installing TeX Live..."
   "$INSTALL_TL_VERSION"/install-tl --profile=texlive.profile
+  $TEXLIVE_BIN/tlmgr install latexmk texliveonfly
   echo "[$0] Installed TeX Live."
 
   touch "$INSTALL_TL_SUCCESS"

--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ if [ ! -e "$INSTALL_TL_SUCCESS" ]; then
   curl -L "$INSTALL_TL_URL" | tar xz --one-top-level=itl --strip-components=1
   echo "$TEXLIVE_PROFILE" > texlive.profile
   itl/install-tl --profile=texlive.profile
-  $TEXLIVE_BIN/tlmgr install latexmk texliveonfly
+  "$TEXLIVE_BIN/tlmgr" install latexmk texliveonfly
   echo "[$0] Installed TeX Live."
 
   touch "$INSTALL_TL_SUCCESS"


### PR DESCRIPTION
(Item 1 from https://github.com/frangio/netlify-latex/issues/6#issuecomment-707937166)

To speed up the initial build, I tried to replace big collections with a minimal set of specific packages, leaving texliveonfly to do the hard work of installing more.

## Performance

I just did a fresh deploy before and after this PR on Netlify (with cache cleared), and got a 1m 58s = 58% reduction.  The improvement is more impressive if you just measure the texlive installation time (time between `[build.sh] Installing TeX Live...` and `[build.sh] Installed TeX Live.` messages): almost 3x faster!

| Version | TeX Live install | texliveonfly run | Total build (as billed by Netlify) |
|---|:---:|:---:|:---:|
| Before PR | 2m 22s | 0m 49s | 3m 23s |
| Alternative | 0m 48s | 1m 24s | 2m 25s |
| After PR | 0m 43s | 0m 32s | 1m 25s |

Of course, there is probably some measurement error here, and the improvement might get better or worse for different examples. But this PR seems in the spirit of this build script of "install just enough and let texliveonfly deal with the rest". And given that it improves both the TeX Live install time and the texliveonfly run, it seems like a pretty sure win. (See below for description of the "Alternative" row in the middle, which was a first version of this PR, where the winning was less clear, where texliveonfly had to do a lot more work.)

## Which collections to include?

http://mirror.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb lists the contents of the various texlive collections. Here are the details for the three that were installed:

* collection-basic (Essential programs and files)
  * Description: "These files are regarded as basic for any TeX system, covering longdesc plain TeX macros, Computer Modern fonts, and configuration for longdesc common drivers; no LaTeX."
  * Dependencies: `amsfonts bibtex cm colorprofiles dvipdfmx dvips ec enctex etex etex-pkg glyphlist graphics-def hyph-utf8 hyphen-base hyphenex ifplatform iftex knuth-lib knuth-local kpathsea lua-alt-getopt luahbtex luatex makeindex metafont mflogo mfware modes pdftex plain tex tex-ini-files texlive-common texlive-docindex texlive-en texlive-msg-translations texlive-scripts texlive.infra tlshell unicode-data xdvi`
  * This seems fairly important, so I've left it in: it has some extra unnecessary items like `xdvi`, but probably hard to tease apart.
* collection-binextra (TeX auxiliary programs)
  * Description: "Myriad additional TeX-related support programs. Includes programs and macros for DVI file manipulation, literate programming, patgen, and plenty more."
  * Dependencies: `a2ping adhocfilelist arara asymptote bibtex8 bibtexu bundledoc checklistings chklref chktex clojure-pamphlet cluttex collection-basic ctan-o-mat ctan_chk ctanbib ctanify ctanupload ctie cweb de-macro detex dtl dtxgen dvi2tty dviasm dvicopy dvidvi dviinfox dviljk dviout-util dvipng dvipos dvisvgm findhyph fragmaster git-latexdiff gsftopk hook-pre-commit-pkg installfont ketcindy lacheck latex-git-log latex-papersize latex2man latex2nemeth latexdiff latexfileversion latexindent latexmk latexpand light-latex-make listings-ext ltxfileinfo ltximg luajittex make4ht match_parens mflua mkjobtexmf patgen pdfbook2 pdfcrop pdfjam pdflatexpicscale pdftex-quiet pdftosrc pdfxup pfarrei pkfix pkfix-helper purifyeps pythontex seetexk spix srcredact sty2dtx synctex tex4ebook texcount texdef texdiff texdirflatten texdoc texdoctk texfot texlive-scripts-extra texliveonfly texloganalyser texosquery texplate texware tie tlcockpit tpic2pdftex typeoutfileinfo web xindex xindy xpdfopen`
  * Conclusion: I think this was just included to get `texliveonfly` and `latexmk`, so just install those instead.
* collection-latex (LaTeX fundamental packages)
  * Description: "These packages are either mandated by the core LaTeX team, or very widely used and strongly recommended in practice."
  * Dependencies: `ae amscls amsmath atbegshi atveryend auxhook babel babel-english babelbib bigintcalc bitset bookmark carlisle collection-basic colortbl epstopdf-pkg etexcmds fancyhdr firstaid fix2col geometry gettitlestring graphics graphics-cfg grfext hopatch hycolor hyperref intcalc kvdefinekeys kvoptions kvsetkeys l3backend l3kernel latex latex-bin latex-fonts latexconfig letltxmacro ltxcmds ltxmisc mfnfss mptopdf natbib oberdiek pagesel pdfescape pslatex psnfss pspicture refcount rerunfilecheck stringenc tools uniquecounter url`
  * This is a pretty small set, and actually do seem like pretty common. In the first version of this PR ("Alternative" row above), I excluded this and just installed `latex latex-bin`. But this caused `texliveonfly` to do a lot more work. So in the final version of the PR, I kept this in.