### PR TITLE
Download install-tl from CTAN instead of inlining

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,9 +19,9 @@ NETLIFY_CACHE_DIR="$NETLIFY_BUILD_BASE/cache"
 TEXLIVE_DIR="$NETLIFY_CACHE_DIR/texlive"
 TEXLIVE_BIN="$TEXLIVE_DIR/2020/bin/x86_64-linux"
 
+INSTALL_TL_URL="http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
 INSTALL_TL="install-tl-unx.tar.gz"
-INSTALL_TL_VERSION="$(tar tf "$INSTALL_TL" | grep -om1 '^install-tl-[0-9]*')"
-INSTALL_TL_SUCCESS="$NETLIFY_CACHE_DIR/$INSTALL_TL_VERSION-success"
+INSTALL_TL_SUCCESS="$NETLIFY_CACHE_DIR/install-tl-success"
 
 TEXLIVEONFLY="$TEXLIVE_DIR/2020/texmf-dist/scripts/texliveonfly/texliveonfly.py"
 
@@ -58,12 +58,13 @@ TEXMFSYSCONFIG $TEXLIVE_DIR/2020/texmf-config
 TEXMFSYSVAR $TEXLIVE_DIR/2020/texmf-var
 "
 
-echo "$TEXLIVE_PROFILE" > texlive.profile
-
 if [ ! -e "$INSTALL_TL_SUCCESS" ]; then
-  tar xf "$INSTALL_TL"
-
   echo "[$0] Installing TeX Live..."
+
+  curl -L "$INSTALL_TL_URL" -o "$INSTALL_TL"
+  tar xf "$INSTALL_TL"
+  echo "$TEXLIVE_PROFILE" > texlive.profile
+  INSTALL_TL_VERSION="$(tar tf "$INSTALL_TL" | grep -om1 '^install-tl-[0-9]*')"
   "$INSTALL_TL_VERSION"/install-tl --profile=texlive.profile
   echo "[$0] Installed TeX Live."
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -euo pipefail
 
 if [ "$#" -eq 0 ]; then
   echo "usage: bash $0 main.tex" >&2
@@ -61,11 +61,9 @@ TEXMFSYSVAR $TEXLIVE_DIR/2020/texmf-var
 if [ ! -e "$INSTALL_TL_SUCCESS" ]; then
   echo "[$0] Installing TeX Live..."
 
-  curl -L "$INSTALL_TL_URL" -o "$INSTALL_TL"
-  tar xf "$INSTALL_TL"
+  curl -L "$INSTALL_TL_URL" | tar xz --one-top-level=itl --strip-components=1
   echo "$TEXLIVE_PROFILE" > texlive.profile
-  INSTALL_TL_VERSION="$(tar tf "$INSTALL_TL" | grep -om1 '^install-tl-[0-9]*')"
-  "$INSTALL_TL_VERSION"/install-tl --profile=texlive.profile
+  itl/install-tl --profile=texlive.profile
   echo "[$0] Installed TeX Live."
 
   touch "$INSTALL_TL_SUCCESS"


### PR DESCRIPTION
(Item 2 from https://github.com/frangio/netlify-latex/issues/6#issuecomment-707937166)

This PR downloads `install-tl` fresh from CTAN instead of requiring it to be manually placed in the repository.  This makes for a smaller/cleaner repository, and has the advantage that no work is required to update `install-tl`.  Instead, you can just clear the Netlify cache to reinstall install-tl and texlive.

I confirmed that this does not appreciably change the initial build time &mdash; latest trial ran in just over 2 minutes with #7 included, and only a couple of seconds for the run of `curl` &mdash; and future builds remain just as fast as before (27s-30s).